### PR TITLE
Add scalars

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,3 +1,6 @@
 {
-  "extends": "eslint-config-neo/config-backend"
+  "extends": "eslint-config-neo/config-backend",
+  "rules": {
+    "import/no-extraneous-dependencies": ["error", { "devDependencies": true }]
+  }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,3 @@
+{
+  "typescript.tsdk": "/Users/markpolivchuk/Code/NeoFinancial/graphql-date-scalars/node_modules/typescript/lib"
+}

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2020 Neo Financial Technologies Inc.
+Copyright (c) 2020 Neo Financial Technologies Inc., Dirk-Jan Rutten
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/package.json
+++ b/package.json
@@ -50,10 +50,15 @@
     "husky": "4.3.0",
     "jest": "^26.5.3",
     "lint-staged": "10.4.2",
-    "prettier": "2.1.2",
+    "prettier": "1.19.1",
     "rimraf": "3.0.2",
     "ts-jest": "^26.4.1",
     "ts-node": "9.0.0",
-    "typescript": "4.0.3"
+    "typescript": "3.9.7"
+  },
+  "dependencies": {
+    "@types/mockdate": "^2.0.0",
+    "jest-matcher-utils": "^26.6.1",
+    "mockdate": "^3.0.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -37,13 +37,16 @@
       "prettier --write"
     ]
   },
-  "dependencies": {},
+  "peerDependencies": {
+    "graphql": "^14.2.0"
+  },
   "devDependencies": {
     "@types/jest": "26.0.14",
     "@types/node": "14.11.10",
     "chalk": "4.1.0",
     "eslint": "7.11.0",
     "eslint-config-neo": "0.5.2",
+    "graphql": "^14.2.0",
     "husky": "4.3.0",
     "jest": "^26.5.3",
     "lint-staged": "10.4.2",

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,1 +1,3 @@
-console.log('hello world!');
+export * from './scalars/date-time';
+export * from './scalars/date';
+export * from './scalars/time';

--- a/src/scalars/date-time.ts
+++ b/src/scalars/date-time.ts
@@ -1,0 +1,54 @@
+import { GraphQLScalarType, ValueNode } from 'graphql';
+
+import { validateDateTime, validateJSDate, serializeDateTime, parseDateTime } from '../utils';
+import { isStringValueNode } from '../utils/type-guards';
+
+/**
+ * An RFC 3339 compliant date-time scalar.
+ *
+ * Input:
+ *    This scalar takes an RFC 3339 date-time string as input and
+ *    parses it to a javascript Date.
+ *
+ * Output:
+ *    This scalar serializes javascript Dates,
+ *    RFC 3339 date-time strings and unix timestamps
+ *    to RFC 3339 UTC date-time strings.
+ */
+const dateTimeScalar = new GraphQLScalarType({
+  name: 'DateTime',
+  description:
+    'A date-time string at UTC, such as 2007-12-03T10:15:30Z, ' +
+    'compliant with the `date-time` format outlined in section 5.6 of ' +
+    'the RFC 3339 profile of the ISO 8601 standard for representation ' +
+    'of dates and times using the Gregorian calendar.',
+  serialize(value: Date): string {
+    if (validateJSDate(value)) {
+      return serializeDateTime(value);
+    }
+
+    throw new TypeError('DateTime cannot represent an invalid Date instance');
+  },
+  parseValue(value: string): Date {
+    if (validateDateTime(value)) {
+      return parseDateTime(value);
+    }
+
+    throw new TypeError(`DateTime cannot represent an invalid date-time-string ${value}.`);
+  },
+  parseLiteral(ast: ValueNode): Date {
+    if (!isStringValueNode(ast)) {
+      throw new TypeError(`DateTime cannot represent non string type ${ast.kind}`);
+    }
+
+    const { value } = ast;
+
+    if (validateDateTime(value)) {
+      return parseDateTime(value);
+    }
+
+    throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`);
+  },
+});
+
+export default dateTimeScalar;

--- a/src/scalars/date-time.ts
+++ b/src/scalars/date-time.ts
@@ -22,6 +22,10 @@ const dateTimeScalar = new GraphQLScalarType({
     'the RFC 3339 profile of the ISO 8601 standard for representation ' +
     'of dates and times using the Gregorian calendar.',
   serialize(value: Date): string {
+    if (!(value instanceof Date)) {
+      throw new TypeError('DateTime cannot represent non-date type');
+    }
+
     if (validateJSDate(value)) {
       return serializeDateTime(value);
     }
@@ -29,6 +33,10 @@ const dateTimeScalar = new GraphQLScalarType({
     throw new TypeError('DateTime cannot represent an invalid Date instance');
   },
   parseValue(value: string): Date {
+    if (typeof value !== 'string') {
+      throw new TypeError(`DateTime cannot represent non string type ${JSON.stringify(value)}`);
+    }
+
     if (validateDateTime(value)) {
       return parseDateTime(value);
     }

--- a/src/scalars/date-time.ts
+++ b/src/scalars/date-time.ts
@@ -12,7 +12,6 @@ import { isStringValueNode } from '../utils/type-guards';
  *
  * Output:
  *    This scalar serializes javascript Dates,
- *    RFC 3339 date-time strings and unix timestamps
  *    to RFC 3339 UTC date-time strings.
  */
 const dateTimeScalar = new GraphQLScalarType({
@@ -48,7 +47,7 @@ const dateTimeScalar = new GraphQLScalarType({
     }
 
     throw new TypeError(`DateTime cannot represent an invalid date-time-string ${String(value)}.`);
-  },
+  }
 });
 
 export default dateTimeScalar;

--- a/src/scalars/date.ts
+++ b/src/scalars/date.ts
@@ -29,6 +29,10 @@ const dateScalar = new GraphQLScalarType({
     throw new TypeError('Date cannot represent an invalid Date instance');
   },
   parseValue(value: string): Date {
+    if (typeof value !== 'string') {
+      throw new TypeError(`Date cannot represent non string type ${JSON.stringify(value)}`);
+    }
+
     const trimmedValue = value.split('T')[0];
 
     if (validateDate(trimmedValue)) {

--- a/src/scalars/date.ts
+++ b/src/scalars/date.ts
@@ -1,0 +1,57 @@
+import { GraphQLScalarType, ValueNode } from 'graphql';
+
+import { validateJSDate, serializeDate, validateDate, parseDate } from '../utils';
+import { isStringValueNode } from '../utils/type-guards';
+
+/**
+ * An RFC 3339 compliant date-time scalar.
+ *
+ * Input:
+ *    This scalar takes an RFC 3339 date-time string as input and
+ *    parses it to a javascript Date.
+ *
+ * Output:
+ *    This scalar serializes javascript Dates,
+ *    RFC 3339 date-time strings and unix timestamps
+ *    to RFC 3339 UTC date-time strings.
+ */
+const dateScalar = new GraphQLScalarType({
+  name: 'Date',
+  description:
+    'A date string, such as 2007-12-03, compliant with the `full-date` ' +
+    'format outlined in section 5.6 of the RFC 3339 profile of the ' +
+    'ISO 8601 standard for representation of dates and times using ' +
+    'the Gregorian calendar.',
+  serialize(value: Date): string {
+    if (validateJSDate(value)) {
+      return serializeDate(value);
+    }
+
+    throw new TypeError('Date cannot represent an invalid Date instance');
+  },
+  parseValue(value: string): Date {
+    const trimmedValue = value.split('T')[0];
+
+    if (validateDate(trimmedValue)) {
+      return parseDate(trimmedValue);
+    }
+
+    throw new TypeError(`Date cannot represent an invalid date-string ${value}.`);
+  },
+  parseLiteral(ast: ValueNode): Date {
+    if (!isStringValueNode(ast)) {
+      throw new TypeError(`Date cannot represent non string type ${ast.kind}`);
+    }
+
+    const { value } = ast;
+    const trimmedValue = value.split('T')[0];
+
+    if (validateDate(trimmedValue)) {
+      return parseDate(trimmedValue);
+    }
+
+    throw new TypeError(`Date cannot represent an invalid date-string ${String(value)}.`);
+  },
+});
+
+export default dateScalar;

--- a/src/scalars/date.ts
+++ b/src/scalars/date.ts
@@ -12,7 +12,6 @@ import { isStringValueNode } from '../utils/type-guards';
  *
  * Output:
  *    This scalar serializes javascript Dates,
- *    RFC 3339 date-time strings and unix timestamps
  *    to RFC 3339 UTC date-time strings.
  */
 const dateScalar = new GraphQLScalarType({
@@ -51,7 +50,7 @@ const dateScalar = new GraphQLScalarType({
     }
 
     throw new TypeError(`Date cannot represent an invalid date-string ${String(value)}.`);
-  },
+  }
 });
 
 export default dateScalar;

--- a/src/scalars/date.ts
+++ b/src/scalars/date.ts
@@ -22,6 +22,10 @@ const dateScalar = new GraphQLScalarType({
     'ISO 8601 standard for representation of dates and times using ' +
     'the Gregorian calendar.',
   serialize(value: Date): string {
+    if (!(value instanceof Date)) {
+      throw new TypeError('Date cannot represent non-date type');
+    }
+
     if (validateJSDate(value)) {
       return serializeDate(value);
     }

--- a/src/scalars/time.ts
+++ b/src/scalars/time.ts
@@ -1,0 +1,54 @@
+import { GraphQLScalarType, ValueNode } from 'graphql';
+
+import { validateTime, validateJSDate, serializeTime, parseTime } from '../utils';
+import { isStringValueNode } from '../utils/type-guards';
+
+/**
+ * An RFC 3339 compliant time scalar.
+ *
+ * Input:
+ *    This scalar takes an RFC 3339 time string as input and
+ *    parses it to a javascript Date (with a year-month-day relative
+ *    to the current day).
+ *
+ * Output:
+ *    This scalar serializes javascript Dates and
+ *    RFC 3339 time strings to RFC 3339 UTC time strings.
+ */
+const timeScalar = new GraphQLScalarType({
+  name: 'Time',
+  description:
+    'A time string at UTC, such as 10:15:30Z, compliant with ' +
+    'the `full-time` format outlined in section 5.6 of the RFC 3339' +
+    'profile of the ISO 8601 standard for representation of dates and ' +
+    'times using the Gregorian calendar.',
+  serialize(value: Date): string {
+    if (validateJSDate(value)) {
+      return serializeTime(value);
+    }
+
+    throw new TypeError('Date cannot represent an invalid Date instance');
+  },
+  parseValue(value: string): Date {
+    if (validateTime(value)) {
+      return parseTime(value);
+    }
+
+    throw new TypeError(`Time cannot represent an invalid time-string ${value}.`);
+  },
+  parseLiteral(ast: ValueNode): Date {
+    if (!isStringValueNode(ast)) {
+      throw new TypeError(`Date cannot represent non string type ${ast.kind}`);
+    }
+
+    const value = ast.value;
+
+    if (validateTime(value)) {
+      return parseTime(value);
+    }
+
+    throw new TypeError(`Time cannot represent an invalid time-string ${String(value)}.`);
+  },
+});
+
+export default timeScalar;

--- a/src/scalars/time.ts
+++ b/src/scalars/time.ts
@@ -23,11 +23,15 @@ const timeScalar = new GraphQLScalarType({
     'profile of the ISO 8601 standard for representation of dates and ' +
     'times using the Gregorian calendar.',
   serialize(value: Date): string {
+    if (!(value instanceof Date)) {
+      throw new TypeError('Time cannot represent non-date type');
+    }
+
     if (validateJSDate(value)) {
       return serializeTime(value);
     }
 
-    throw new TypeError('Date cannot represent an invalid Date instance');
+    throw new TypeError('Time cannot represent an invalid Date instance');
   },
   parseValue(value: string): Date {
     if (typeof value !== 'string') {
@@ -42,7 +46,7 @@ const timeScalar = new GraphQLScalarType({
   },
   parseLiteral(ast: ValueNode): Date {
     if (!isStringValueNode(ast)) {
-      throw new TypeError(`Date cannot represent non string type ${ast.kind}`);
+      throw new TypeError(`Time cannot represent non string type ${ast.kind}`);
     }
 
     const value = ast.value;

--- a/src/scalars/time.ts
+++ b/src/scalars/time.ts
@@ -13,7 +13,7 @@ import { isStringValueNode } from '../utils/type-guards';
  *
  * Output:
  *    This scalar serializes javascript Dates and
- *    RFC 3339 time strings to RFC 3339 UTC time strings.
+ *    to RFC 3339 UTC time strings.
  */
 const timeScalar = new GraphQLScalarType({
   name: 'Time',
@@ -48,7 +48,7 @@ const timeScalar = new GraphQLScalarType({
     }
 
     throw new TypeError(`Time cannot represent an invalid time-string ${String(value)}.`);
-  },
+  }
 });
 
 export default timeScalar;

--- a/src/scalars/time.ts
+++ b/src/scalars/time.ts
@@ -30,6 +30,10 @@ const timeScalar = new GraphQLScalarType({
     throw new TypeError('Date cannot represent an invalid Date instance');
   },
   parseValue(value: string): Date {
+    if (typeof value !== 'string') {
+      throw new TypeError(`Time cannot represent non string type ${JSON.stringify(value)}`);
+    }
+
     if (validateTime(value)) {
       return parseTime(value);
     }

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -20,48 +20,6 @@ export const serializeTime = (date: Date): string => {
   return dateTimeString.slice(dateTimeString.indexOf('T') + 1);
 };
 
-// Serializes an RFC 3339 compliant time-string by shifting
-// it to UTC.
-export const serializeTimeString = (time: string): string => {
-  // If already formatted to UTC then return the time string
-  if (time.includes('Z')) {
-    return time;
-  } else {
-    // These are time-strings with timezone information,
-    // these need to be shifted to UTC.
-
-    // Convert to UTC time string in
-    // format hh:mm:ss.sssZ.
-    const date = parseTime(time);
-    let timeUTC = serializeTime(date);
-
-    // Regex to look for fractional second part in time string
-    // such as 00:00:00.345+01:00
-    const regexFracSec = /\.\d{1,}/;
-
-    // Retrieve the fractional second part of the time
-    // string if it exists.
-    const fractionalPart = time.match(regexFracSec);
-
-    if (fractionalPart == null) {
-      // These are time-strings without the fractional
-      // seconds. So we remove them from the UTC time-string.
-      timeUTC = timeUTC.replace(regexFracSec, '');
-
-      return timeUTC;
-    } else {
-      // These are time-string with fractional seconds.
-      // Make sure that we inject the fractional
-      // second part back in. The `timeUTC` variable
-      // has millisecond precision, we may want more or less
-      // depending on the string that was passed.
-      timeUTC = timeUTC.replace(regexFracSec, fractionalPart[0]);
-
-      return timeUTC;
-    }
-  }
-};
-
 // Parses an RFC 3339 compliant date-string into a Date.
 //
 // Example:
@@ -86,50 +44,4 @@ export const parseDateTime = (dateTime: string): Date => {
 // in the format YYYY-MM-DDThh:mm:ss.sssZ.
 export const serializeDateTime = (dateTime: Date): string => {
   return dateTime.toISOString();
-};
-
-// Serializes an RFC 3339 compliant date-time-string by shifting
-// it to UTC.
-export const serializeDateTimeString = (dateTime: string): string => {
-  // If already formatted to UTC then return the time string
-  if (dateTime.includes('Z')) {
-    return dateTime;
-  } else {
-    // These are time-strings with timezone information,
-    // these need to be shifted to UTC.
-
-    // Convert to UTC time string in
-    // format YYYY-MM-DDThh:mm:ss.sssZ.
-    let dateTimeUTC = new Date(dateTime).toISOString();
-
-    // Regex to look for fractional second part in date-time string
-    const regexFracSec = /\.\d{1,}/;
-
-    // Retrieve the fractional second part of the time
-    // string if it exists.
-    const fractionalPart = dateTime.match(regexFracSec);
-
-    if (fractionalPart == null) {
-      // The date-time-string has no fractional part,
-      // so we remove it from the dateTimeUTC variable.
-      dateTimeUTC = dateTimeUTC.replace(regexFracSec, '');
-
-      return dateTimeUTC;
-    } else {
-      // These are datetime-string with fractional seconds.
-      // Make sure that we inject the fractional
-      // second part back in. The `dateTimeUTC` variable
-      // has millisecond precision, we may want more or less
-      // depending on the string that was passed.
-      dateTimeUTC = dateTimeUTC.replace(regexFracSec, fractionalPart[0]);
-
-      return dateTimeUTC;
-    }
-  }
-};
-
-// Serializes a Unix timestamp to an RFC 3339 compliant date-time-string
-// in the format YYYY-MM-DDThh:mm:ss.sssZ
-export const serializeUnixTimestamp = (timestamp: number): string => {
-  return new Date(timestamp * 1000).toISOString();
 };

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/prefer-string-slice */
+
 // Parses an RFC 3339 compliant time-string into a Date.
 // It does this by combining the current date with the time-string
 // to create a new Date instance.
@@ -9,7 +11,7 @@
 export const parseTime = (time: string): Date => {
   const currentDateString = new Date().toISOString();
 
-  return new Date(currentDateString.slice(0, currentDateString.indexOf('T') + 1) + time);
+  return new Date(currentDateString.substr(0, currentDateString.indexOf('T') + 1) + time);
 };
 
 // Serializes a Date into an RFC 3339 compliant time-string in the
@@ -17,7 +19,7 @@ export const parseTime = (time: string): Date => {
 export const serializeTime = (date: Date): string => {
   const dateTimeString = date.toISOString();
 
-  return dateTimeString.slice(dateTimeString.indexOf('T') + 1);
+  return dateTimeString.substr(dateTimeString.indexOf('T') + 1);
 };
 
 // Parses an RFC 3339 compliant date-string into a Date.

--- a/src/utils/formatter.ts
+++ b/src/utils/formatter.ts
@@ -1,0 +1,135 @@
+// Parses an RFC 3339 compliant time-string into a Date.
+// It does this by combining the current date with the time-string
+// to create a new Date instance.
+//
+// Example:
+// Suppose the current date is 2016-01-01, then
+// parseTime('11:00:12Z') parses to a Date corresponding to
+// 2016-01-01T11:00:12Z.
+export const parseTime = (time: string): Date => {
+  const currentDateString = new Date().toISOString();
+
+  return new Date(currentDateString.slice(0, currentDateString.indexOf('T') + 1) + time);
+};
+
+// Serializes a Date into an RFC 3339 compliant time-string in the
+// format hh:mm:ss.sssZ.
+export const serializeTime = (date: Date): string => {
+  const dateTimeString = date.toISOString();
+
+  return dateTimeString.slice(dateTimeString.indexOf('T') + 1);
+};
+
+// Serializes an RFC 3339 compliant time-string by shifting
+// it to UTC.
+export const serializeTimeString = (time: string): string => {
+  // If already formatted to UTC then return the time string
+  if (time.includes('Z')) {
+    return time;
+  } else {
+    // These are time-strings with timezone information,
+    // these need to be shifted to UTC.
+
+    // Convert to UTC time string in
+    // format hh:mm:ss.sssZ.
+    const date = parseTime(time);
+    let timeUTC = serializeTime(date);
+
+    // Regex to look for fractional second part in time string
+    // such as 00:00:00.345+01:00
+    const regexFracSec = /\.\d{1,}/;
+
+    // Retrieve the fractional second part of the time
+    // string if it exists.
+    const fractionalPart = time.match(regexFracSec);
+
+    if (fractionalPart == null) {
+      // These are time-strings without the fractional
+      // seconds. So we remove them from the UTC time-string.
+      timeUTC = timeUTC.replace(regexFracSec, '');
+
+      return timeUTC;
+    } else {
+      // These are time-string with fractional seconds.
+      // Make sure that we inject the fractional
+      // second part back in. The `timeUTC` variable
+      // has millisecond precision, we may want more or less
+      // depending on the string that was passed.
+      timeUTC = timeUTC.replace(regexFracSec, fractionalPart[0]);
+
+      return timeUTC;
+    }
+  }
+};
+
+// Parses an RFC 3339 compliant date-string into a Date.
+//
+// Example:
+// parseDate('2016-01-01') parses to a Date corresponding to
+// 2016-01-01T00:00:00.000Z.
+export const parseDate = (date: string): Date => {
+  return new Date(date);
+};
+
+// Serializes a Date into a RFC 3339 compliant date-string
+// in the format YYYY-MM-DD.
+export const serializeDate = (date: Date): string => {
+  return date.toISOString().split('T')[0];
+};
+
+// Parses an RFC 3339 compliant date-time-string into a Date.
+export const parseDateTime = (dateTime: string): Date => {
+  return new Date(dateTime);
+};
+
+// Serializes a Date into an RFC 3339 compliant date-time-string
+// in the format YYYY-MM-DDThh:mm:ss.sssZ.
+export const serializeDateTime = (dateTime: Date): string => {
+  return dateTime.toISOString();
+};
+
+// Serializes an RFC 3339 compliant date-time-string by shifting
+// it to UTC.
+export const serializeDateTimeString = (dateTime: string): string => {
+  // If already formatted to UTC then return the time string
+  if (dateTime.includes('Z')) {
+    return dateTime;
+  } else {
+    // These are time-strings with timezone information,
+    // these need to be shifted to UTC.
+
+    // Convert to UTC time string in
+    // format YYYY-MM-DDThh:mm:ss.sssZ.
+    let dateTimeUTC = new Date(dateTime).toISOString();
+
+    // Regex to look for fractional second part in date-time string
+    const regexFracSec = /\.\d{1,}/;
+
+    // Retrieve the fractional second part of the time
+    // string if it exists.
+    const fractionalPart = dateTime.match(regexFracSec);
+
+    if (fractionalPart == null) {
+      // The date-time-string has no fractional part,
+      // so we remove it from the dateTimeUTC variable.
+      dateTimeUTC = dateTimeUTC.replace(regexFracSec, '');
+
+      return dateTimeUTC;
+    } else {
+      // These are datetime-string with fractional seconds.
+      // Make sure that we inject the fractional
+      // second part back in. The `dateTimeUTC` variable
+      // has millisecond precision, we may want more or less
+      // depending on the string that was passed.
+      dateTimeUTC = dateTimeUTC.replace(regexFracSec, fractionalPart[0]);
+
+      return dateTimeUTC;
+    }
+  }
+};
+
+// Serializes a Unix timestamp to an RFC 3339 compliant date-time-string
+// in the format YYYY-MM-DDThh:mm:ss.sssZ
+export const serializeUnixTimestamp = (timestamp: number): string => {
+  return new Date(timestamp * 1000).toISOString();
+};

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,0 +1,13 @@
+export {
+  serializeTime,
+  serializeTimeString,
+  serializeDate,
+  serializeDateTime,
+  serializeDateTimeString,
+  serializeUnixTimestamp,
+  parseTime,
+  parseDate,
+  parseDateTime,
+} from './formatter';
+
+export { validateTime, validateDate, validateDateTime, validateUnixTimestamp, validateJSDate } from './validator';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,13 +1,3 @@
-export {
-  serializeTime,
-  serializeTimeString,
-  serializeDate,
-  serializeDateTime,
-  serializeDateTimeString,
-  serializeUnixTimestamp,
-  parseTime,
-  parseDate,
-  parseDateTime,
-} from './formatter';
+export { serializeTime, serializeDate, serializeDateTime, parseTime, parseDate, parseDateTime } from './formatter';
 
 export { validateTime, validateDate, validateDateTime, validateUnixTimestamp, validateJSDate } from './validator';

--- a/src/utils/index.ts
+++ b/src/utils/index.ts
@@ -1,3 +1,3 @@
 export { serializeTime, serializeDate, serializeDateTime, parseTime, parseDate, parseDateTime } from './formatter';
 
-export { validateTime, validateDate, validateDateTime, validateUnixTimestamp, validateJSDate } from './validator';
+export { validateTime, validateDate, validateDateTime, validateJSDate } from './validator';

--- a/src/utils/type-guards.ts
+++ b/src/utils/type-guards.ts
@@ -1,0 +1,7 @@
+import { Kind, StringValueNode, ValueNode } from 'graphql';
+
+const isStringValueNode = (ast: ValueNode): ast is StringValueNode => {
+  return ast.kind === Kind.STRING;
+};
+
+export { isStringValueNode };

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,3 +1,5 @@
+/* eslint-disable unicorn/prefer-string-slice */
+
 // Check whether a certain year is a leap year.
 //
 // Every year that is exactly divisible by four
@@ -72,9 +74,9 @@ export const validateDate = (dateString: string): boolean => {
 
   // Verify the correct number of days for
   // the month contained in the date-string.
-  const year = Number(dateString.slice(0, 4));
-  const month = Number(dateString.slice(5, 2));
-  const day = Number(dateString.slice(8, 2));
+  const year = Number(dateString.substr(0, 4));
+  const month = Number(dateString.substr(5, 2));
+  const day = Number(dateString.substr(8, 2));
 
   switch (month) {
     case 2: // February
@@ -128,23 +130,10 @@ export const validateDateTime = (dateTimeString: string): boolean => {
   // Split the date-time-string up into the string-date and time-string part.
   // and check whether these parts are RFC 3339 compliant.
   const index = dateTimeString.indexOf('T');
-  const dateString = dateTimeString.slice(0, index);
-  const timeString = dateTimeString.slice(index + 1);
+  const dateString = dateTimeString.substr(0, index);
+  const timeString = dateTimeString.substr(index + 1);
 
   return validateDate(dateString) && validateTime(timeString);
-};
-
-// Function that checks whether a given number is a valid
-// Unix timestamp.
-//
-// Unix timestamps are signed 32-bit integers. They are interpreted
-// as the number of seconds since 00:00:00 UTC on 1 January 1970.
-//
-export const validateUnixTimestamp = (timestamp: number): boolean => {
-  const MAX_INT = 2147483647;
-  const MIN_INT = -2147483648;
-
-  return timestamp === timestamp && timestamp <= MAX_INT && timestamp >= MIN_INT;
 };
 
 // Function that checks whether a javascript Date instance

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -1,0 +1,157 @@
+// Check whether a certain year is a leap year.
+//
+// Every year that is exactly divisible by four
+// is a leap year, except for years that are exactly
+// divisible by 100, but these centurial years are
+// leap years if they are exactly divisible by 400.
+// For example, the years 1700, 1800, and 1900 are not leap years,
+// but the years 1600 and 2000 are.
+//
+const leapYear = (year: number): boolean => {
+  return (year % 4 === 0 && year % 100 !== 0) || year % 400 === 0;
+};
+
+// Function that checks whether a time-string is RFC 3339 compliant.
+//
+// It checks whether the time-string is structured in one of the
+// following formats:
+//
+// - hh:mm:ssZ
+// - hh:mm:ss±hh:mm
+// - hh:mm:ss.*sZ
+// - hh:mm:ss.*s±hh:mm
+//
+// Where *s is a fraction of seconds with at least 1 digit.
+//
+// Note, this validator assumes that all minutes have
+// 59 seconds. This assumption does not follow RFC 3339
+// which includes leap seconds (in which case it is possible that
+// there are 60 seconds in a minute).
+//
+// Leap seconds are ignored because it adds complexity in
+// the following areas:
+// - The native Javascript Date ignores them; i.e. Date.parse('1972-12-31T23:59:60Z')
+//   equals NaN.
+// - Leap seconds cannot be known in advance.
+//
+export const validateTime = (time: string): boolean => {
+  const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d{1,})?(([Z])|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
+
+  return TIME_REGEX.test(time);
+};
+
+// Function that checks whether a date-string is RFC 3339 compliant.
+//
+// It checks whether the date-string is a valid date in the YYYY-MM-DD.
+//
+// Note, the number of days in each date are determined according to the
+// following lookup table:
+//
+// Month Number  Month/Year           Maximum value of date-mday
+// ------------  ----------           --------------------------
+// 01            January              31
+// 02            February, normal     28
+// 02            February, leap year  29
+// 03            March                31
+// 04            April                30
+// 05            May                  31
+// 06            June                 30
+// 07            July                 31
+// 08            August               31
+// 09            September            30
+// 10            October              31
+// 11            November             30
+// 12            December             31
+//
+export const validateDate = (dateString: string): boolean => {
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01]))$/;
+
+  if (!RFC_3339_REGEX.test(dateString)) {
+    return false;
+  }
+
+  // Verify the correct number of days for
+  // the month contained in the date-string.
+  const year = Number(dateString.slice(0, 4));
+  const month = Number(dateString.slice(5, 2));
+  const day = Number(dateString.slice(8, 2));
+
+  switch (month) {
+    case 2: // February
+      if (leapYear(year) && day > 29) {
+        return false;
+      } else if (!leapYear(year) && day > 28) {
+        return false;
+      }
+
+      return true;
+    case 4: // April
+    case 6: // June
+    case 9: // September
+    case 11: // November
+      if (day > 30) {
+        return false;
+      }
+
+      break;
+  }
+
+  return true;
+};
+
+// Function that checks whether a date-time-string is RFC 3339 compliant.
+//
+// It checks whether the time-string is structured in one of the
+//
+// - YYYY-MM-DDThh:mm:ssZ
+// - YYYY-MM-DDThh:mm:ss±hh:mm
+// - YYYY-MM-DDThh:mm:ss.*sZ
+// - YYYY-MM-DDThh:mm:ss.*s±hh:mm
+//
+// Where *s is a fraction of seconds with at least 1 digit.
+//
+export const validateDateTime = (dateTimeString: string): boolean => {
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60))(\.\d{1,})?(([Z])|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
+
+  // Validate the structure of the date-string
+  if (!RFC_3339_REGEX.test(dateTimeString)) {
+    return false;
+  }
+
+  // Check if it is a correct date using the javascript Date parse() method.
+  const time = Date.parse(dateTimeString);
+
+  if (time !== time) {
+    return false;
+  }
+
+  // Split the date-time-string up into the string-date and time-string part.
+  // and check whether these parts are RFC 3339 compliant.
+  const index = dateTimeString.indexOf('T');
+  const dateString = dateTimeString.slice(0, index);
+  const timeString = dateTimeString.slice(index + 1);
+
+  return validateDate(dateString) && validateTime(timeString);
+};
+
+// Function that checks whether a given number is a valid
+// Unix timestamp.
+//
+// Unix timestamps are signed 32-bit integers. They are interpreted
+// as the number of seconds since 00:00:00 UTC on 1 January 1970.
+//
+export const validateUnixTimestamp = (timestamp: number): boolean => {
+  const MAX_INT = 2147483647;
+  const MIN_INT = -2147483648;
+
+  return timestamp === timestamp && timestamp <= MAX_INT && timestamp >= MIN_INT;
+};
+
+// Function that checks whether a javascript Date instance
+// is valid.
+//
+export const validateJSDate = (date: Date): boolean => {
+  const time = date.getTime();
+
+  return time === time;
+};

--- a/test/scalars/__snapshots__/date-time.test.ts.snap
+++ b/test/scalars/__snapshots__/date-time.test.ts.snap
@@ -1,0 +1,53 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`DateTime scalar has a description 1`] = `"A date-time string at UTC, such as 2007-12-03T10:15:30Z, compliant with the \`date-time\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "BooleanValue", "value": false} 1`] = `"DateTime cannot represent non string type BooleanValue"`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"DateTime cannot represent non string type FloatValue"`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2015-02-24T00:00:00.000+0100"} 1`] = `"DateTime cannot represent an invalid date-time-string 2015-02-24T00:00:00.000+0100."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00:00.Z"} 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00:00.Z."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00:00Z"} 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00Z."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T000059Z"} 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T000059Z."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2016-02-01T00Z"} 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00Z."`;
+
+exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"DateTime cannot represent an invalid date-time-string Invalid date."`;
+
+exports[`DateTime scalar serialization throws error when serializing [] 1`] = `"date.getTime is not a function"`;
+
+exports[`DateTime scalar serialization throws error when serializing {} 1`] = `"date.getTime is not a function"`;
+
+exports[`DateTime scalar serialization throws error when serializing invalid date 1`] = `"DateTime cannot represent an invalid Date instance"`;
+
+exports[`DateTime scalar serialization throws error when serializing null 1`] = `"Cannot read property 'getTime' of null"`;
+
+exports[`DateTime scalar serialization throws error when serializing true 1`] = `"date.getTime is not a function"`;
+
+exports[`DateTime scalar serialization throws error when serializing undefined 1`] = `"Cannot read property 'getTime' of undefined"`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"DateTime cannot represent an invalid date-time-string 2015-02-24T00:00:00.000+0100."`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2016-02-01T00:00:00.Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00:00.Z."`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2016-02-01T00:00Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00:00Z."`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2016-02-01T000059Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T000059Z."`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2016-02-01T00Z" 1`] = `"DateTime cannot represent an invalid date-time-string 2016-02-01T00Z."`;
+
+exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"DateTime cannot represent an invalid date-time-string Invalid date."`;
+
+exports[`DateTime scalar value parsing throws an error when parsing [] 1`] = `"DateTime cannot represent an invalid date-time-string ."`;
+
+exports[`DateTime scalar value parsing throws an error when parsing {} 1`] = `"DateTime cannot represent an invalid date-time-string [object Object]."`;
+
+exports[`DateTime scalar value parsing throws an error when parsing 4566 1`] = `"DateTime cannot represent an invalid date-time-string 4566."`;
+
+exports[`DateTime scalar value parsing throws an error when parsing null 1`] = `"DateTime cannot represent an invalid date-time-string null."`;
+
+exports[`DateTime scalar value parsing throws an error when parsing true 1`] = `"DateTime cannot represent an invalid date-time-string true."`;

--- a/test/scalars/__snapshots__/date-time.test.ts.snap
+++ b/test/scalars/__snapshots__/date-time.test.ts.snap
@@ -18,17 +18,17 @@ exports[`DateTime scalar literal parsing errors when parsing invalid literal {"k
 
 exports[`DateTime scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"DateTime cannot represent an invalid date-time-string Invalid date."`;
 
-exports[`DateTime scalar serialization throws error when serializing [] 1`] = `"date.getTime is not a function"`;
+exports[`DateTime scalar serialization throws error when serializing [] 1`] = `"DateTime cannot represent non-date type"`;
 
-exports[`DateTime scalar serialization throws error when serializing {} 1`] = `"date.getTime is not a function"`;
+exports[`DateTime scalar serialization throws error when serializing {} 1`] = `"DateTime cannot represent non-date type"`;
 
 exports[`DateTime scalar serialization throws error when serializing invalid date 1`] = `"DateTime cannot represent an invalid Date instance"`;
 
-exports[`DateTime scalar serialization throws error when serializing null 1`] = `"Cannot read property 'getTime' of null"`;
+exports[`DateTime scalar serialization throws error when serializing null 1`] = `"DateTime cannot represent non-date type"`;
 
-exports[`DateTime scalar serialization throws error when serializing true 1`] = `"date.getTime is not a function"`;
+exports[`DateTime scalar serialization throws error when serializing true 1`] = `"DateTime cannot represent non-date type"`;
 
-exports[`DateTime scalar serialization throws error when serializing undefined 1`] = `"Cannot read property 'getTime' of undefined"`;
+exports[`DateTime scalar serialization throws error when serializing undefined 1`] = `"DateTime cannot represent non-date type"`;
 
 exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "2015-02-24T00:00:00.000+0100" 1`] = `"DateTime cannot represent an invalid date-time-string 2015-02-24T00:00:00.000+0100."`;
 
@@ -42,12 +42,12 @@ exports[`DateTime scalar value parsing throws an error parsing an invalid date-s
 
 exports[`DateTime scalar value parsing throws an error parsing an invalid date-string "Invalid date" 1`] = `"DateTime cannot represent an invalid date-time-string Invalid date."`;
 
-exports[`DateTime scalar value parsing throws an error when parsing [] 1`] = `"DateTime cannot represent an invalid date-time-string ."`;
+exports[`DateTime scalar value parsing throws an error when parsing [] 1`] = `"DateTime cannot represent non string type []"`;
 
-exports[`DateTime scalar value parsing throws an error when parsing {} 1`] = `"DateTime cannot represent an invalid date-time-string [object Object]."`;
+exports[`DateTime scalar value parsing throws an error when parsing {} 1`] = `"DateTime cannot represent non string type {}"`;
 
-exports[`DateTime scalar value parsing throws an error when parsing 4566 1`] = `"DateTime cannot represent an invalid date-time-string 4566."`;
+exports[`DateTime scalar value parsing throws an error when parsing 4566 1`] = `"DateTime cannot represent non string type 4566"`;
 
-exports[`DateTime scalar value parsing throws an error when parsing null 1`] = `"DateTime cannot represent an invalid date-time-string null."`;
+exports[`DateTime scalar value parsing throws an error when parsing null 1`] = `"DateTime cannot represent non string type null"`;
 
-exports[`DateTime scalar value parsing throws an error when parsing true 1`] = `"DateTime cannot represent an invalid date-time-string true."`;
+exports[`DateTime scalar value parsing throws an error when parsing true 1`] = `"DateTime cannot represent non string type true"`;

--- a/test/scalars/__snapshots__/date.test.ts.snap
+++ b/test/scalars/__snapshots__/date.test.ts.snap
@@ -1,0 +1,41 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Date scalar has a description 1`] = `"A date string, such as 2007-12-03, compliant with the \`full-date\` format outlined in section 5.6 of the RFC 3339 profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
+
+exports[`Date scalar literal parsing errors when parsing invalid literal {"kind": "BooleanValue", "value": false} 1`] = `"Date cannot represent non string type BooleanValue"`;
+
+exports[`Date scalar literal parsing errors when parsing invalid literal {"kind": "FloatValue", "value": "5"} 1`] = `"Date cannot represent non string type FloatValue"`;
+
+exports[`Date scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2015-02-29"} 1`] = `"Date cannot represent an invalid date-string 2015-02-29."`;
+
+exports[`Date scalar literal parsing errors when parsing invalid literal {"kind": "StringValue", "value": "invalid date"} 1`] = `"Date cannot represent an invalid date-string invalid date."`;
+
+exports[`Date scalar serialization throws an error when serializing an invalid date-string "2015-02-29" 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws an error when serializing an invalid date-string "invalid date" 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws error when serializing [] 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws error when serializing {} 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws error when serializing invalid javascript Date 1`] = `"Date cannot represent an invalid Date instance"`;
+
+exports[`Date scalar serialization throws error when serializing null 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws error when serializing true 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar serialization throws error when serializing undefined 1`] = `"Date cannot represent non-date type"`;
+
+exports[`Date scalar value parsing throws an error parsing an invalid datetime-string "2015-02-29" 1`] = `"Date cannot represent an invalid date-string 2015-02-29."`;
+
+exports[`Date scalar value parsing throws an error parsing an invalid datetime-string "invalid date" 1`] = `"Date cannot represent an invalid date-string invalid date."`;
+
+exports[`Date scalar value parsing throws an error when parsing [] 1`] = `"Date cannot represent non string type []"`;
+
+exports[`Date scalar value parsing throws an error when parsing {} 1`] = `"Date cannot represent non string type {}"`;
+
+exports[`Date scalar value parsing throws an error when parsing 4566 1`] = `"Date cannot represent non string type 4566"`;
+
+exports[`Date scalar value parsing throws an error when parsing null 1`] = `"Date cannot represent non string type null"`;
+
+exports[`Date scalar value parsing throws an error when parsing true 1`] = `"Date cannot represent non string type true"`;

--- a/test/scalars/__snapshots__/time.test.ts.snap
+++ b/test/scalars/__snapshots__/time.test.ts.snap
@@ -1,0 +1,55 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Time scalar has a description 1`] = `"A time string at UTC, such as 10:15:30Z, compliant with the \`full-time\` format outlined in section 5.6 of the RFC 3339profile of the ISO 8601 standard for representation of dates and times using the Gregorian calendar."`;
+
+exports[`Time scalar literial parsing errors when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+01"} 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+01."`;
+
+exports[`Time scalar literial parsing errors when parsing invalid literal {"kind": "StringValue", "value": "00:00:00.45+0130"} 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+0130."`;
+
+exports[`Time scalar literial parsing errors when parsing invalid literal {"kind": "StringValue", "value": "10:30:02.Z"} 1`] = `"Time cannot represent an invalid time-string 10:30:02.Z."`;
+
+exports[`Time scalar literial parsing errors when parsing invalid literal {"kind": "StringValue", "value": "2016-01-01T00:00:00.223Z"} 1`] = `"Time cannot represent an invalid time-string 2016-01-01T00:00:00.223Z."`;
+
+exports[`Time scalar literial parsing errors when parsing invalid literal {"kind": "StringValue", "value": "Invalid date"} 1`] = `"Time cannot represent an invalid time-string Invalid date."`;
+
+exports[`Time scalar serialization throws an error when serializing an invalid date-string "00:00:00.45+01" 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws an error when serializing an invalid date-string "00:00:00.45+0130" 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws an error when serializing an invalid date-string "10:30:02.Z" 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws an error when serializing an invalid date-string "2016-01-01T00:00:00.223Z" 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws an error when serializing an invalid date-string "Invalid date" 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws error when serializing [] 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws error when serializing {} 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws error when serializing invalid date 1`] = `"Time cannot represent an invalid Date instance"`;
+
+exports[`Time scalar serialization throws error when serializing null 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws error when serializing true 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar serialization throws error when serializing undefined 1`] = `"Time cannot represent non-date type"`;
+
+exports[`Time scalar value parsing throws an error parsing an invalid time-string "00:00:00.45+01" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+01."`;
+
+exports[`Time scalar value parsing throws an error parsing an invalid time-string "00:00:00.45+0130" 1`] = `"Time cannot represent an invalid time-string 00:00:00.45+0130."`;
+
+exports[`Time scalar value parsing throws an error parsing an invalid time-string "10:30:02.Z" 1`] = `"Time cannot represent an invalid time-string 10:30:02.Z."`;
+
+exports[`Time scalar value parsing throws an error parsing an invalid time-string "2016-01-01T00:00:00.223Z" 1`] = `"Time cannot represent an invalid time-string 2016-01-01T00:00:00.223Z."`;
+
+exports[`Time scalar value parsing throws an error parsing an invalid time-string "Invalid date" 1`] = `"Time cannot represent an invalid time-string Invalid date."`;
+
+exports[`Time scalar value parsing throws an error when parsing [] 1`] = `"Time cannot represent non string type []"`;
+
+exports[`Time scalar value parsing throws an error when parsing {} 1`] = `"Time cannot represent non string type {}"`;
+
+exports[`Time scalar value parsing throws an error when parsing 4566 1`] = `"Time cannot represent non string type 4566"`;
+
+exports[`Time scalar value parsing throws an error when parsing null 1`] = `"Time cannot represent non string type null"`;
+
+exports[`Time scalar value parsing throws an error when parsing true 1`] = `"Time cannot represent non string type true"`;

--- a/test/scalars/date-time.test.ts
+++ b/test/scalars/date-time.test.ts
@@ -1,5 +1,3 @@
-/* eslint-disable @typescript-eslint/no-explicit-any */
-
 import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, Kind } from 'graphql';
 import { stringify } from 'jest-matcher-utils';
 
@@ -122,7 +120,7 @@ describe('DateTime scalar', () => {
 
 describe('DateTime integration', () => {
   const schema = new GraphQLSchema({
-    query: new GraphQLObjectType<any, any, { [key: string]: any }>({
+    query: new GraphQLObjectType({
       name: 'Query',
       fields: {
         validDate: {

--- a/test/scalars/date-time.test.ts
+++ b/test/scalars/date-time.test.ts
@@ -1,0 +1,120 @@
+import { Kind } from 'graphql';
+
+import { stringify } from 'jest-matcher-utils';
+
+import DateTimeScalar from '../../src/scalars/date-time';
+
+describe('DateTime scalar', () => {
+  const invalidDates = [
+    // General
+    'Invalid date',
+    // Datetime with hours
+    '2016-02-01T00Z',
+    // Datetime with hours and minutes
+    '2016-02-01T00:00Z',
+    // Datetime with hours, minutes and seconds
+    '2016-02-01T000059Z',
+    // Datetime with hours, minutes, seconds and fractional seconds
+    '2016-02-01T00:00:00.Z',
+    // Datetime with hours, minutes, seconds, fractional seconds and timezone.
+    '2015-02-24T00:00:00.000+0100'
+  ];
+
+  const validDates: [string, Date][] = [
+    // Datetime with hours, minutes and seconds
+    ['2016-02-01T00:00:15Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 15))],
+    ['2016-02-01T00:00:00-11:00', new Date(Date.UTC(2016, 1, 1, 11))],
+    ['2017-01-07T11:25:00+01:00', new Date(Date.UTC(2017, 0, 7, 10, 25))],
+    ['2017-01-07T00:00:00+01:20', new Date(Date.UTC(2017, 0, 6, 22, 40))],
+    // Datetime with hours, minutes, seconds and fractional seconds
+    ['2016-02-01T00:00:00.1Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 100))],
+    ['2016-02-01T00:00:00.000Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 0))],
+    ['2016-02-01T00:00:00.990Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 990))],
+    ['2016-02-01T00:00:00.23498Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 234))],
+    ['2017-01-07T11:25:00.450+01:00', new Date(Date.UTC(2017, 0, 7, 10, 25, 0, 450))]
+  ];
+
+  it('has a description', () => {
+    expect(DateTimeScalar.description).toMatchSnapshot();
+  });
+
+  describe('serialization', () => {
+    [{}, [], null, undefined, true].forEach(invalidInput => {
+      it(`throws error when serializing ${stringify(invalidInput)}`, () => {
+        expect(() => DateTimeScalar.serialize(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    [
+      [new Date(Date.UTC(2016, 0, 1)), '2016-01-01T00:00:00.000Z'],
+      [new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 30)), '2016-01-01T14:48:10.030Z']
+    ].forEach(([value, expected]) => {
+      it(`serializes javascript Date ${stringify(value)} into ${stringify(expected)}`, () => {
+        expect(DateTimeScalar.serialize(value)).toEqual(expected);
+      });
+    });
+
+    it(`throws error when serializing invalid date`, () => {
+      expect(() => DateTimeScalar.serialize(new Date('invalid date'))).toThrowErrorMatchingSnapshot();
+    });
+  });
+
+  describe('value parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      it(`parses date-string ${stringify(value)} into javascript Date ${stringify(expected)}`, () => {
+        expect(DateTimeScalar.parseValue(value)).toEqual(expected);
+      });
+    });
+
+    [4566, {}, [], true, null].forEach(invalidInput => {
+      it(`throws an error when parsing ${stringify(invalidInput)}`, () => {
+        expect(() => DateTimeScalar.parseValue(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    invalidDates.forEach(dateString => {
+      it(`throws an error parsing an invalid date-string ${stringify(dateString)}`, () => {
+        expect(() => DateTimeScalar.parseValue(dateString)).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('literal parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      const literal = {
+        kind: Kind.STRING,
+        value
+      };
+
+      it(`parses literal ${stringify(literal)} into javascript Date ${stringify(expected)}`, () => {
+        expect(DateTimeScalar.parseLiteral(literal, {})).toEqual(expected);
+      });
+    });
+
+    invalidDates.forEach(value => {
+      const invalidLiteral = {
+        kind: Kind.STRING,
+        value
+      };
+
+      it(`errors when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() => DateTimeScalar.parseLiteral(invalidLiteral, {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    [
+      {
+        kind: Kind.FLOAT,
+        value: '5'
+      },
+      {
+        kind: Kind.BOOLEAN,
+        value: false
+      }
+    ].forEach(literal => {
+      it(`errors when parsing invalid literal ${stringify(literal)}`, () => {
+        expect(() => DateTimeScalar.parseLiteral(literal, {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+});

--- a/test/scalars/date.test.ts
+++ b/test/scalars/date.test.ts
@@ -1,0 +1,283 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, Kind } from 'graphql';
+import { stringify } from 'jest-matcher-utils';
+
+import DateScalar from '../../src/scalars/date';
+
+describe('Date scalar', () => {
+  const invalidDates = ['invalid date', '2015-02-29'];
+
+  const validDates: [string, Date][] = [
+    ['2016-12-17', new Date(Date.UTC(2016, 11, 17))],
+    ['2016-02-01', new Date(Date.UTC(2016, 1, 1))]
+  ];
+
+  test('has a description', () => {
+    expect(DateScalar.description).toMatchSnapshot();
+  });
+
+  describe('serialization', () => {
+    [{}, [], null, undefined, true].forEach(invalidInput => {
+      test(`throws error when serializing ${stringify(invalidInput)}`, () => {
+        expect(() => DateScalar.serialize(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    [
+      [new Date(Date.UTC(2016, 11, 17, 14)), '2016-12-17'],
+      [new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 3)), '2016-01-01'],
+      [new Date(Date.UTC(2016, 0, 1)), '2016-01-01']
+    ].forEach(([value, expected]) => {
+      test(`serializes javascript Date ${stringify(value)} into ${stringify(expected)}`, () => {
+        expect(DateScalar.serialize(value)).toEqual(expected);
+      });
+    });
+
+    test(`throws error when serializing invalid javascript Date`, () => {
+      expect(() => DateScalar.serialize(new Date('invalid date'))).toThrowErrorMatchingSnapshot();
+    });
+
+    invalidDates.forEach(dateString => {
+      test(`throws an error when serializing an invalid date-string ${stringify(dateString)}`, () => {
+        expect(() => DateScalar.serialize(dateString)).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('value parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      test(`parses date-string ${stringify(value)} into javascript Date ${stringify(expected)}`, () => {
+        expect(DateScalar.parseValue(value)).toEqual(expected);
+      });
+    });
+
+    [4566, {}, [], true, null].forEach(invalidInput => {
+      test(`throws an error when parsing ${stringify(invalidInput)}`, () => {
+        expect(() => DateScalar.parseValue(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    invalidDates.forEach(dateString => {
+      test(`throws an error parsing an invalid datetime-string ${stringify(dateString)}`, () => {
+        expect(() => DateScalar.parseValue(dateString)).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('literal parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      const literal = {
+        kind: Kind.STRING,
+        value
+      };
+
+      test(`parses literal ${stringify(literal)} into javascript Date ${stringify(expected)}`, () => {
+        expect(DateScalar.parseLiteral(literal, {})).toEqual(expected);
+      });
+    });
+
+    invalidDates.forEach(value => {
+      const invalidLiteral = {
+        kind: Kind.STRING,
+        value
+      };
+
+      test(`errors when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() => DateScalar.parseLiteral(invalidLiteral, {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    [
+      {
+        kind: Kind.FLOAT,
+        value: '5'
+      },
+      {
+        kind: Kind.BOOLEAN,
+        value: false
+      }
+    ].forEach(literal => {
+      test(`errors when parsing invalid literal ${stringify(literal)}`, () => {
+        expect(() => DateScalar.parseLiteral(literal, {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+});
+
+describe('Date integration', () => {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        validDate: {
+          type: DateScalar,
+          resolve: () => new Date('2016-05-02')
+        },
+        invalidDate: {
+          type: DateScalar,
+          resolve: () => new Date('wrong')
+        },
+        invalidType: {
+          type: DateScalar,
+          resolve: () => 5
+        },
+        input: {
+          type: DateScalar,
+          args: {
+            date: {
+              type: DateScalar
+            }
+          },
+          resolve: (_, input) => input.date
+        }
+      }
+    })
+  });
+
+  it('executes a query that includes a date', async () => {
+    const query = `
+     query DateTest($date: Date!) {
+       validDate
+       input(date: $date)
+       inputNull: input
+     }
+   `;
+
+    const variables = { date: '2017-10-01' };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      data: {
+        validDate: '2016-05-02',
+        input: '2017-10-01',
+        inputNull: null
+      }
+    });
+  });
+
+  it('parses input to a JS Date', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          input: {
+            type: DateScalar,
+            args: {
+              date: {
+                type: DateScalar
+              }
+            },
+            resolve: (_, input) => {
+              expect(input.date).toEqual(new Date(Date.UTC(2016, 11, 17)));
+            }
+          }
+        }
+      })
+    });
+
+    const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+    const variables = { date: '2016-12-17' };
+
+    graphql(schema, query, null, null, variables);
+  });
+
+  it('errors if there is an invalid date returned from the resolver', async () => {
+    const query = `
+     {
+       invalidDate
+       invalidType
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      data: {
+        invalidDate: null,
+        invalidType: null
+      },
+      errors: [
+        new GraphQLError('Date cannot represent an invalid Date instance'),
+        new GraphQLError('Date cannot represent non-date type')
+      ]
+    });
+  });
+
+  it('errors if the variable value is not a valid date', async () => {
+    const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+
+    const variables = { date: '2017-10-001' };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Variable "$date" got invalid value "2017-10-001"; Expected type Date. Date cannot represent an invalid date-string 2017-10-001.'
+        )
+      ]
+    });
+  });
+
+  it('errors if the variable value is not of type string', async () => {
+    const query = `
+     query DateTest($date: Date!) {
+       input(date: $date)
+     }
+   `;
+
+    const variables = { date: 4 };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Variable "$date" got invalid value 4; Expected type Date. Date cannot represent non string type 4'
+        )
+      ]
+    });
+  });
+
+  it('errors if the literal input value is not a valid date', async () => {
+    const query = `
+     {
+       input(date: "2017-10-001")
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Expected type Date, found "2017-10-001"; Date cannot represent an invalid date-string 2017-10-001.'
+        )
+      ]
+    });
+  });
+
+  it('errors if the literal input value in a query is not a string', async () => {
+    const query = `
+     {
+       input(date: 4)
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      errors: [new GraphQLError('Expected type Date, found 4; Date cannot represent non string type IntValue')]
+    });
+  });
+});

--- a/test/scalars/time.test.ts
+++ b/test/scalars/time.test.ts
@@ -1,0 +1,312 @@
+/* eslint-disable @typescript-eslint/no-explicit-any */
+
+import { graphql, GraphQLObjectType, GraphQLSchema, GraphQLError, Kind } from 'graphql';
+import { stringify } from 'jest-matcher-utils';
+import MockDate from 'mockdate';
+
+import TimeScalar from '../../src/scalars/time';
+
+// Mock the new Date() call so it always returns 2017-01-01T00:00:00.000Z
+MockDate.set(new Date(Date.UTC(2017, 0, 1)));
+
+describe('Time scalar', () => {
+  const invalidDates = ['Invalid date', '2016-01-01T00:00:00.223Z', '10:30:02.Z', '00:00:00.45+0130', '00:00:00.45+01'];
+
+  const validDates: [string, Date][] = [
+    ['00:00:00Z', new Date(Date.UTC(2017, 0, 1))],
+    ['00:00:59Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 59))],
+    ['10:30:02.1Z', new Date(Date.UTC(2017, 0, 1, 10, 30, 2, 100))],
+    ['09:09:06.13Z', new Date(Date.UTC(2017, 0, 1, 9, 9, 6, 130))],
+    ['10:00:11.003Z', new Date(Date.UTC(2017, 0, 1, 10, 0, 11, 3))],
+    ['16:10:20.1359945Z', new Date(Date.UTC(2017, 0, 1, 16, 10, 20, 135))],
+    ['00:00:00+01:30', new Date(Date.UTC(2016, 11, 31, 22, 30))],
+    ['00:00:30.3-01:30', new Date(Date.UTC(2017, 0, 1, 1, 30, 30, 300))]
+  ];
+
+  test('has a description', () => {
+    expect(TimeScalar.description).toMatchSnapshot();
+  });
+
+  describe('serialization', () => {
+    [{}, [], null, undefined, true].forEach(invalidInput => {
+      test(`throws error when serializing ${stringify(invalidInput)}`, () => {
+        expect(() => TimeScalar.serialize(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    // Serialize from Date
+    [
+      [new Date(Date.UTC(2016, 0, 1)), '00:00:00.000Z'],
+      [new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 3)), '14:48:10.003Z']
+    ].forEach(([value, expected]) => {
+      test(`serializes javascript Date ${stringify(value)} into ${stringify(expected)}`, () => {
+        expect(TimeScalar.serialize(value)).toEqual(expected);
+      });
+    });
+
+    test(`throws error when serializing invalid date`, () => {
+      expect(() => TimeScalar.serialize(new Date('invalid date'))).toThrowErrorMatchingSnapshot();
+    });
+
+    invalidDates.forEach(dateString => {
+      test(`throws an error when serializing an invalid date-string ${stringify(dateString)}`, () => {
+        expect(() => TimeScalar.serialize(dateString)).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('value parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      test(`parses date-string ${stringify(value)} into javascript Date ${stringify(expected)}`, () => {
+        expect(TimeScalar.parseValue(value)).toEqual(expected);
+      });
+    });
+
+    [4566, {}, [], true, null].forEach(invalidInput => {
+      test(`throws an error when parsing ${stringify(invalidInput)}`, () => {
+        expect(() => TimeScalar.parseValue(invalidInput)).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    invalidDates.forEach(dateString => {
+      test(`throws an error parsing an invalid time-string ${stringify(dateString)}`, () => {
+        expect(() => TimeScalar.parseValue(dateString)).toThrowErrorMatchingSnapshot();
+      });
+    });
+  });
+
+  describe('literial parsing', () => {
+    validDates.forEach(([value, expected]) => {
+      const literal = {
+        kind: Kind.STRING,
+        value
+      };
+
+      test(`parses literal ${stringify(literal)} into javascript Date ${stringify(expected)}`, () => {
+        expect(TimeScalar.parseLiteral(literal, {})).toEqual(expected);
+      });
+    });
+
+    invalidDates.forEach(value => {
+      const invalidLiteral = {
+        kind: Kind.STRING,
+        value
+      };
+
+      test(`errors when parsing invalid literal ${stringify(invalidLiteral)}`, () => {
+        expect(() => TimeScalar.parseLiteral(invalidLiteral, {})).toThrowErrorMatchingSnapshot();
+      });
+    });
+
+    [
+      {
+        kind: Kind.FLOAT,
+        value: '5'
+      },
+      {
+        kind: Kind.BOOLEAN,
+        value: false
+      }
+    ].forEach(literal => {
+      test(`errors when parsing invalid literal ${stringify(literal)}`, () => {
+        expect(() => TimeScalar.parseLiteral(literal, {})).toThrow();
+      });
+    });
+  });
+});
+
+describe('Time integration', () => {
+  const schema = new GraphQLSchema({
+    query: new GraphQLObjectType({
+      name: 'Query',
+      fields: {
+        validJSDate: {
+          type: TimeScalar,
+          resolve: () => new Date(Date.UTC(2016, 0, 1, 14, 48, 10, 3))
+        },
+        invalidJSDate: {
+          type: TimeScalar,
+          resolve: () => new Date('wrong')
+        },
+        invalidType: {
+          type: TimeScalar,
+          resolve: () => 5
+        },
+        input: {
+          type: TimeScalar,
+          args: {
+            time: {
+              type: TimeScalar
+            }
+          },
+          resolve: (_, input) => input.time
+        }
+      }
+    })
+  });
+
+  test('executes a query that includes a time', async () => {
+    const query = `
+     query TimeTest($time: Time!) {
+       validJSDate
+       input(time: $time)
+       inputNull: input
+     }
+   `;
+
+    const variables = { time: '14:30:00Z' };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      data: {
+        validJSDate: '14:48:10.003Z',
+        input: '14:30:00.000Z',
+        inputNull: null
+      }
+    });
+  });
+
+  test('shifts an input time to UTC', async () => {
+    const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+    const variables = { time: '00:00:00+01:30' };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      data: {
+        input: '22:30:00.000Z'
+      }
+    });
+  });
+
+  test('parses input to a JS Date', () => {
+    const schema = new GraphQLSchema({
+      query: new GraphQLObjectType({
+        name: 'Query',
+        fields: {
+          input: {
+            type: TimeScalar,
+            args: {
+              time: {
+                type: TimeScalar
+              }
+            },
+            resolve: (_, input) => {
+              expect(input.time).toEqual(new Date(Date.UTC(2016, 11, 31, 22, 30)));
+            }
+          }
+        }
+      })
+    });
+
+    const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+    const variables = { time: '00:00:00+01:30' };
+
+    graphql(schema, query, null, null, variables);
+  });
+
+  test('errors if there is an invalid time returned from the resolver', async () => {
+    const query = `
+     {
+       invalidJSDate
+       invalidType
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      data: {
+        invalidJSDate: null,
+        invalidType: null
+      },
+      errors: [
+        new GraphQLError('Time cannot represent an invalid Date instance'),
+        new GraphQLError('Time cannot represent non-date type')
+      ]
+    });
+  });
+
+  test('errors if the variable value is not a valid time', async () => {
+    const query = `
+     query TimeTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+    const variables = { time: '__2222' };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Variable "$time" got invalid value "__2222"; Expected type Time. Time cannot represent an invalid time-string __2222.'
+        )
+      ]
+    });
+  });
+
+  test('errors if the variable value is not of type string', async () => {
+    const query = `
+     query DateTest($time: Time!) {
+       input(time: $time)
+     }
+   `;
+
+    const variables = { time: 4 };
+
+    const response = await graphql(schema, query, null, null, variables);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Variable "$time" got invalid value 4; Expected type Time. Time cannot represent non string type 4'
+        )
+      ]
+    });
+  });
+
+  test('errors if the literal input value is not a valid time', async () => {
+    const query = `
+     {
+       input(time: "__invalid__")
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      errors: [
+        new GraphQLError(
+          'Expected type Time, found "__invalid__"; Time cannot represent an invalid time-string __invalid__.'
+        )
+      ]
+    });
+  });
+
+  test('errors if the literal input value in a query is not a string', async () => {
+    const query = `
+     {
+       input(time: 4)
+     }
+   `;
+
+    const response = await graphql(schema, query);
+
+    expect(response).toEqual({
+      errors: [new GraphQLError('Expected type Time, found 4; Time cannot represent non string type IntValue')]
+    });
+  });
+});

--- a/test/tsconfig.json
+++ b/test/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "extends": "../tsconfig.json",
+  "compilerOptions": {
+    "strictNullChecks": false
+  },
+  "include": ["../src/**/*", "./**/*"]
+}

--- a/test/utils/formatter.test.ts
+++ b/test/utils/formatter.test.ts
@@ -13,16 +13,13 @@ import {
 // Mock the new Date() call so it always returns 2017-01-01T00:00:00.000Z
 MockDate.set(new Date(Date.UTC(2017, 0, 1)));
 
-type DateToString = [Date, string];
-type StringToDate = [string, Date];
-
 describe('formatting', () => {
   [
     [new Date(Date.UTC(2016, 1, 1)), '00:00:00.000Z'],
     [new Date(Date.UTC(2016, 1, 1, 2, 4, 10, 344)), '02:04:10.344Z']
-  ].forEach(([date, time]: DateToString) => {
+  ].forEach(([date, time]) => {
     test(`serializes ${stringify(date)} into time-string ${time}`, () => {
-      expect(serializeTime(date)).toEqual(time);
+      expect(serializeTime(date as Date)).toEqual(time);
     });
   });
 
@@ -30,27 +27,27 @@ describe('formatting', () => {
     [new Date(Date.UTC(2016, 1, 1)), '2016-02-01'],
     [new Date(Date.UTC(2016, 1, 1, 4, 5, 5)), '2016-02-01'],
     [new Date(Date.UTC(2016, 2, 3)), '2016-03-03']
-  ].forEach(([date, dateString]: DateToString) => {
+  ].forEach(([date, dateString]) => {
     test(`serializes ${stringify(date)} into date-string ${dateString}`, () => {
-      expect(serializeDate(date)).toEqual(dateString);
+      expect(serializeDate(date as Date)).toEqual(dateString);
     });
   });
 
   [
     [new Date(Date.UTC(2016, 1, 1)), '2016-02-01T00:00:00.000Z'],
     [new Date(Date.UTC(2016, 3, 5, 10, 1, 4, 555)), '2016-04-05T10:01:04.555Z']
-  ].forEach(([date, dateTimeString]: DateToString) => {
+  ].forEach(([date, dateTimeString]) => {
     test(`serializes ${stringify(date)} into date-time-string ${dateTimeString}`, () => {
-      expect(serializeDateTime(date)).toEqual(dateTimeString);
+      expect(serializeDateTime(date as Date)).toEqual(dateTimeString);
     });
   });
 
   [
     [new Date(Date.UTC(2016, 1, 1)), '2016-02-01T00:00:00.000Z'],
     [new Date(Date.UTC(2016, 3, 5, 10, 1, 4, 555)), '2016-04-05T10:01:04.555Z']
-  ].forEach(([date, dateTimeString]: DateToString) => {
+  ].forEach(([date, dateTimeString]) => {
     test(`serializes ${stringify(date)} into date-time-string ${dateTimeString}`, () => {
-      expect(serializeDateTime(date)).toEqual(dateTimeString);
+      expect(serializeDateTime(date as Date)).toEqual(dateTimeString);
     });
   });
 
@@ -66,18 +63,18 @@ describe('formatting', () => {
     ['00:00:00.12399Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 123))],
     ['00:00:00.450+01:30', new Date(Date.UTC(2016, 11, 31, 22, 30, 0, 450))],
     ['00:00:00.450-01:30', new Date(Date.UTC(2017, 0, 1, 1, 30, 0, 450))]
-  ].forEach(([time, date]: StringToDate) => {
+  ].forEach(([time, date]) => {
     it(`parses time ${stringify(time)} into Date ${stringify(date)}`, () => {
-      expect(parseTime(time)).toEqual(date);
+      expect(parseTime(time as string)).toEqual(date);
     });
   });
 
   [
     ['2016-12-17', new Date(Date.UTC(2016, 11, 17))],
     ['2016-02-01', new Date(Date.UTC(2016, 1, 1))]
-  ].forEach(([dateString, date]: StringToDate) => {
+  ].forEach(([dateString, date]) => {
     it(`parses date ${stringify(dateString)} into Date ${stringify(date)}`, () => {
-      expect(parseDate(dateString)).toEqual(date);
+      expect(parseDate(dateString as string)).toEqual(date);
     });
   });
 
@@ -96,9 +93,9 @@ describe('formatting', () => {
     ['2016-02-01T00:00:00.000Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 0))],
     ['2016-02-01T00:00:00.993Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 993))],
     ['2017-01-07T11:25:00.450+01:00', new Date(Date.UTC(2017, 0, 7, 10, 25, 0, 450))]
-  ].forEach(([dateTime, date]: StringToDate) => {
+  ].forEach(([dateTime, date]) => {
     it(`parses date-time ${stringify(dateTime)} into Date ${stringify(date)}`, () => {
-      expect(parseDateTime(dateTime)).toEqual(date);
+      expect(parseDateTime(dateTime as string)).toEqual(date);
     });
   });
 });

--- a/test/utils/formatter.test.ts
+++ b/test/utils/formatter.test.ts
@@ -1,0 +1,104 @@
+import MockDate from 'mockdate';
+import { stringify } from 'jest-matcher-utils';
+
+import {
+  serializeTime,
+  serializeDate,
+  serializeDateTime,
+  parseTime,
+  parseDate,
+  parseDateTime
+} from '../../src/utils/formatter';
+
+// Mock the new Date() call so it always returns 2017-01-01T00:00:00.000Z
+MockDate.set(new Date(Date.UTC(2017, 0, 1)));
+
+type DateToString = [Date, string];
+type StringToDate = [string, Date];
+
+describe('formatting', () => {
+  [
+    [new Date(Date.UTC(2016, 1, 1)), '00:00:00.000Z'],
+    [new Date(Date.UTC(2016, 1, 1, 2, 4, 10, 344)), '02:04:10.344Z']
+  ].forEach(([date, time]: DateToString) => {
+    test(`serializes ${stringify(date)} into time-string ${time}`, () => {
+      expect(serializeTime(date)).toEqual(time);
+    });
+  });
+
+  [
+    [new Date(Date.UTC(2016, 1, 1)), '2016-02-01'],
+    [new Date(Date.UTC(2016, 1, 1, 4, 5, 5)), '2016-02-01'],
+    [new Date(Date.UTC(2016, 2, 3)), '2016-03-03']
+  ].forEach(([date, dateString]: DateToString) => {
+    test(`serializes ${stringify(date)} into date-string ${dateString}`, () => {
+      expect(serializeDate(date)).toEqual(dateString);
+    });
+  });
+
+  [
+    [new Date(Date.UTC(2016, 1, 1)), '2016-02-01T00:00:00.000Z'],
+    [new Date(Date.UTC(2016, 3, 5, 10, 1, 4, 555)), '2016-04-05T10:01:04.555Z']
+  ].forEach(([date, dateTimeString]: DateToString) => {
+    test(`serializes ${stringify(date)} into date-time-string ${dateTimeString}`, () => {
+      expect(serializeDateTime(date)).toEqual(dateTimeString);
+    });
+  });
+
+  [
+    [new Date(Date.UTC(2016, 1, 1)), '2016-02-01T00:00:00.000Z'],
+    [new Date(Date.UTC(2016, 3, 5, 10, 1, 4, 555)), '2016-04-05T10:01:04.555Z']
+  ].forEach(([date, dateTimeString]: DateToString) => {
+    test(`serializes ${stringify(date)} into date-time-string ${dateTimeString}`, () => {
+      expect(serializeDateTime(date)).toEqual(dateTimeString);
+    });
+  });
+
+  [
+    ['00:00:59Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 59))],
+    ['00:00:00+01:30', new Date(Date.UTC(2016, 11, 31, 22, 30))],
+    ['00:00:00.1Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 100))],
+    ['00:00:00.12Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 120))],
+    ['00:00:00.000Z', new Date(Date.UTC(2017, 0, 1))],
+    ['00:00:00.993Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 993))],
+    ['00:00:00.123456Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 123))],
+    // No rounding takes place!
+    ['00:00:00.12399Z', new Date(Date.UTC(2017, 0, 1, 0, 0, 0, 123))],
+    ['00:00:00.450+01:30', new Date(Date.UTC(2016, 11, 31, 22, 30, 0, 450))],
+    ['00:00:00.450-01:30', new Date(Date.UTC(2017, 0, 1, 1, 30, 0, 450))]
+  ].forEach(([time, date]: StringToDate) => {
+    it(`parses time ${stringify(time)} into Date ${stringify(date)}`, () => {
+      expect(parseTime(time)).toEqual(date);
+    });
+  });
+
+  [
+    ['2016-12-17', new Date(Date.UTC(2016, 11, 17))],
+    ['2016-02-01', new Date(Date.UTC(2016, 1, 1))]
+  ].forEach(([dateString, date]: StringToDate) => {
+    it(`parses date ${stringify(dateString)} into Date ${stringify(date)}`, () => {
+      expect(parseDate(dateString)).toEqual(date);
+    });
+  });
+
+  [
+    // Datetime with hours, minutes and seconds
+    ['2016-02-01T00:00:00Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0))],
+    ['2016-02-01T00:00:15Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 15))],
+    ['2016-02-01T00:00:59Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 59))],
+    ['2016-02-01T00:00:00-11:00', new Date(Date.UTC(2016, 1, 1, 11))],
+    ['2017-01-07T11:25:00+01:00', new Date(Date.UTC(2017, 0, 7, 10, 25))],
+    ['2017-01-07T00:00:00+01:00', new Date(Date.UTC(2017, 0, 6, 23))],
+    // Datetime with hours, minutes, seconds and fractional seconds.
+    ['2016-02-01T00:00:00.12Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 120))],
+    ['2016-02-01T00:00:00.123456Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 123))],
+    ['2016-02-01T00:00:00.12399Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 123))],
+    ['2016-02-01T00:00:00.000Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 0))],
+    ['2016-02-01T00:00:00.993Z', new Date(Date.UTC(2016, 1, 1, 0, 0, 0, 993))],
+    ['2017-01-07T11:25:00.450+01:00', new Date(Date.UTC(2017, 0, 7, 10, 25, 0, 450))]
+  ].forEach(([dateTime, date]: StringToDate) => {
+    it(`parses date-time ${stringify(dateTime)} into Date ${stringify(date)}`, () => {
+      expect(parseDateTime(dateTime)).toEqual(date);
+    });
+  });
+});

--- a/test/utils/validator.test.ts
+++ b/test/utils/validator.test.ts
@@ -1,0 +1,172 @@
+/* eslint-disable unicorn/prefer-string-slice */
+
+import { validateTime, validateDate, validateDateTime, validateJSDate } from '../../src/utils/validator';
+
+describe('validator', () => {
+  describe('validateTime', () => {
+    [
+      '00:00:00Z',
+      '23:00:00Z',
+      '10:59:00Z',
+      '00:11:59Z',
+      '00:00:00+01:30',
+      '00:00:00-01:30',
+      '00:00:00.1Z',
+      '00:00:00.1-01:30',
+      '00:00:00.34Z',
+      '00:00:00.34-01:30',
+      '00:00:00.000Z',
+      '00:00:00.999Z',
+      '00:00:00.450+01:30',
+      '00:00:00.450-01:30',
+      '00:00:00.450-23:00',
+      '00:00:00.450-00:59',
+      '00:00:00.45643222345664443Z',
+      '00:00:00.3455334564433+01:00'
+    ].forEach(time => {
+      test(`identifies ${time} as a valid time`, () => {
+        expect(validateTime(time)).toEqual(true);
+      });
+    });
+
+    [
+      'Invalid date',
+      '00Z',
+      // Time with hours and minutes
+      '00:00Z',
+      // Time with hours, minutes and seconds
+      '000059Z',
+      '00:00:0Z',
+      '00:00:00',
+      '24:00:00Z',
+      '13:60:00Z',
+      '00:00:60Z',
+      '13:60:61Z',
+      '00:00:00+01',
+      '00:00:00+0100',
+      // Time with hours, minutes, seconds and fractional seconds
+      '00:00:00.Z',
+      '00:00:00.223',
+      '00:00:00.000+0100',
+      '00:00:00.000+01',
+      '00:00:00.000+24:00',
+      '00:00:00.000+00:60',
+      // Date
+      '2016-01-01T00:00:00.223Z',
+      '2016-01-01T00Z'
+    ].forEach(time => {
+      test(`identifies ${time} as an invalid date`, () => {
+        expect(validateTime(time)).toEqual(false);
+      });
+    });
+  });
+
+  describe('validateDate', () => {
+    [
+      '2016-12-17',
+      '2016-02-01',
+      '0000-01-01',
+      '9999-01-01',
+      '2016-02-29',
+      '2000-02-29',
+      '2016-05-31',
+      '2016-11-20'
+    ].forEach(date => {
+      test(`identifies ${date} as a valid date`, () => {
+        expect(validateDate(date)).toEqual(true);
+      });
+    });
+
+    [
+      'invalid date',
+      '2016',
+      '2016-01',
+      '21233',
+      '2016-02-01T25',
+      '2016-02-01T00Z',
+      '2016-02-01T00:00:00.223Z',
+      '2015-02-29',
+      '1900-02-29',
+      '20162-12-11',
+      '2015-13-11',
+      '2015-8-32',
+      '2015-111',
+      '2016-04-31',
+      '2016-06-31',
+      '2016-09-31',
+      '2016-11-31',
+      '2016-02-30',
+      '9999-00-31'
+    ].forEach(date => {
+      test(`identifies ${date} as an invalid date`, () => {
+        expect(validateDate(date)).toEqual(false);
+      });
+    });
+  });
+
+  describe('validateDateTime', () => {
+    [
+      // Datetime with hours, minutes and seconds
+      '2016-02-01T00:00:00Z',
+      '2016-02-01T00:00:15Z',
+      '2016-02-01T00:00:59Z',
+      '2016-02-01T00:00:00-11:00',
+      '2017-01-07T11:25:00+01:00',
+      '2017-01-07T00:00:00+01:00',
+      // Datetime with hours, minutes, seconds and fractional seconds
+      '2017-01-07T00:00:00.0Z',
+      '2017-01-01T00:00:00.0+01:00',
+      '2016-02-01T00:00:00.000Z',
+      '2016-02-01T00:00:00.990Z',
+      '2016-02-01T00:00:00.450Z',
+      '2017-01-07T11:25:00.450+01:00',
+      '2017-01-01T10:23:11.45686664Z',
+      '2017-01-01T10:23:11.23545654+01:00'
+    ].forEach(dateTime => {
+      test(`identifies ${dateTime} as a valid date-time`, () => {
+        expect(validateDateTime(dateTime)).toEqual(true);
+      });
+    });
+
+    [
+      'Invalid date',
+      // Date-time with hours
+      '2016-02-01T00Z',
+      // Date-time with hours and minutes
+      '2016-02-01T00:00Z',
+      // Date-time with hours, minutes and seconds
+      '2016-02-01T000059Z',
+      '2016-02-01T00:00:60Z',
+      '2016-02-01T00:00:0Z',
+      '2015-02-29T00:00:00Z',
+      '2016-02-01T00:00:00',
+      '2017-01-07T11:25:00+0100',
+      '2017-01-07T11:25:00+01',
+      '2017-01-07T11:25:00+',
+      // Date-time with hours, minutes, seconds and fractional seconds
+      '2015-02-26T00:00:00.Z',
+      '2015-02-29T00:00:00.000Z',
+      '2016-02-01T00:00:00.223',
+      '2016-02-01T00:00:00',
+      '2017-01-07T11:25:00.450+0100',
+      '2017-01-07T11:25:00.450+01',
+      '2017-44-07T11:25:00.450+01:00',
+      '2017-01-07T25:25:00.450+01:00',
+      '2017-01-07T11:11:11+24:00'
+    ].forEach(dateTime => {
+      test(`identifies ${dateTime} as an invalid date-time`, () => {
+        expect(validateDateTime(dateTime)).toEqual(false);
+      });
+    });
+  });
+
+  describe('validateJSDate', () => {
+    test('identifies invalid Date', () => {
+      expect(validateJSDate(new Date('invalid'))).toBeFalsy();
+    });
+
+    test('identifies a valid Date', () => {
+      expect(validateJSDate(new Date(2016, 1, 1))).toBeTruthy();
+    });
+  });
+});

--- a/yarn.lock
+++ b/yarn.lock
@@ -2134,6 +2134,13 @@ graceful-fs@^4.1.2, graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
+graphql@^14.2.0:
+  version "14.7.0"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-14.7.0.tgz#7fa79a80a69be4a31c27dda824dc04dac2035a72"
+  integrity sha512-l0xWZpoPKpppFzMfvVyFmp9vLN7w/ZZJPefUicMCepfJeQ8sMcztloGYY9DfjVPo6tIUDzU5Hw3MUbIjj9AVVA==
+  dependencies:
+    iterall "^1.2.2"
+
 growly@^1.3.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
@@ -2596,6 +2603,11 @@ istanbul-reports@^3.0.2:
   dependencies:
     html-escaper "^2.0.0"
     istanbul-lib-report "^3.0.0"
+
+iterall@^1.2.2:
+  version "1.3.0"
+  resolved "https://registry.yarnpkg.com/iterall/-/iterall-1.3.0.tgz#afcb08492e2915cbd8a0884eb93a8c94d0d72fea"
+  integrity sha512-QZ9qOMdF+QLHxy1QIpUHUU1D5pS2CG2P69LF6L6CPjPYA/XMOmKV3PZpawHoAjHNyB0swdVTRxdYT4tbBbxqwg==
 
 jest-changed-files@^26.5.2:
   version "26.5.2"

--- a/yarn.lock
+++ b/yarn.lock
@@ -485,6 +485,17 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
+"@jest/types@^26.6.1":
+  version "26.6.1"
+  resolved "https://registry.yarnpkg.com/@jest/types/-/types-26.6.1.tgz#2638890e8031c0bc8b4681e0357ed986e2f866c5"
+  integrity sha512-ywHavIKNpAVrStiRY5wiyehvcktpijpItvGiK72RAn5ctqmzvPk8OvKnvHeBqa1XdQr959CTWAJMqxI8BTibyg==
+  dependencies:
+    "@types/istanbul-lib-coverage" "^2.0.0"
+    "@types/istanbul-reports" "^3.0.0"
+    "@types/node" "*"
+    "@types/yargs" "^15.0.0"
+    chalk "^4.0.0"
+
 "@sinonjs/commons@^1.7.0":
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/@sinonjs/commons/-/commons-1.8.1.tgz#e7df00f98a203324f6dc7cc606cad9d4a8ab2217"
@@ -588,6 +599,11 @@
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
   integrity sha1-7ihweulOEdK4J7y+UnC86n8+ce4=
+
+"@types/mockdate@^2.0.0":
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/@types/mockdate/-/mockdate-2.0.0.tgz#aaf388a1ead3b0f5ed6dc1611956ea7b40a57d3c"
+  integrity sha1-qvOIoerTsPXtbcFhGVbqe0ClfTw=
 
 "@types/node@*", "@types/node@14.11.10":
   version "14.11.10"
@@ -2681,6 +2697,16 @@ jest-diff@^26.5.2:
     jest-get-type "^26.3.0"
     pretty-format "^26.5.2"
 
+jest-diff@^26.6.1:
+  version "26.6.1"
+  resolved "https://registry.yarnpkg.com/jest-diff/-/jest-diff-26.6.1.tgz#38aa194979f454619bb39bdee299fb64ede5300c"
+  integrity sha512-BBNy/zin2m4kG5In126O8chOBxLLS/XMTuuM2+YhgyHk87ewPzKTuTJcqj3lOWOi03NNgrl+DkMeV/exdvG9gg==
+  dependencies:
+    chalk "^4.0.0"
+    diff-sequences "^26.5.0"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.1"
+
 jest-docblock@^26.0.0:
   version "26.0.0"
   resolved "https://registry.yarnpkg.com/jest-docblock/-/jest-docblock-26.0.0.tgz#3e2fa20899fc928cb13bd0ff68bd3711a36889b5"
@@ -2796,6 +2822,16 @@ jest-matcher-utils@^26.5.2:
     jest-diff "^26.5.2"
     jest-get-type "^26.3.0"
     pretty-format "^26.5.2"
+
+jest-matcher-utils@^26.6.1:
+  version "26.6.1"
+  resolved "https://registry.yarnpkg.com/jest-matcher-utils/-/jest-matcher-utils-26.6.1.tgz#bc90822d352c91c2ec1814731327691d06598400"
+  integrity sha512-9iu3zrsYlUnl8pByhREF9rr5eYoiEb1F7ymNKg6lJr/0qD37LWS5FSW/JcoDl8UdMX2+zAzabDs7sTO+QFKjCg==
+  dependencies:
+    chalk "^4.0.0"
+    jest-diff "^26.6.1"
+    jest-get-type "^26.3.0"
+    pretty-format "^26.6.1"
 
 jest-message-util@^26.5.2:
   version "26.5.2"
@@ -3413,6 +3449,11 @@ mkdirp@^0.5.1:
   dependencies:
     minimist "^1.2.5"
 
+mockdate@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/mockdate/-/mockdate-3.0.2.tgz#a5a7bb5820da617747af424d7a4dcb22c6c03d79"
+  integrity sha512-ldfYSUW1ocqSHGTK6rrODUiqAFPGAg0xaHqYJ5tvj1hQyFsjuHpuWgWFTZWwDVlzougN/s2/mhDr8r5nY5xDpA==
+
 ms@2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/ms/-/ms-2.0.0.tgz#5608aeadfc00be6c2901df5f9861788de0d597c8"
@@ -3832,10 +3873,10 @@ prelude-ls@~1.1.2:
   resolved "https://registry.yarnpkg.com/prelude-ls/-/prelude-ls-1.1.2.tgz#21932a549f5e52ffd9a827f570e04be62a97da54"
   integrity sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=
 
-prettier@2.1.2:
-  version "2.1.2"
-  resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.1.2.tgz#3050700dae2e4c8b67c4c3f666cdb8af405e1ce5"
-  integrity sha512-16c7K+x4qVlJg9rEbXl7HEGmQyZlG4R9AgP+oHKRMsMsuk8s+ATStlf1NpDqyBI1HpVyfjLOeMhH2LvuNvV5Vg==
+prettier@1.19.1:
+  version "1.19.1"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-1.19.1.tgz#f7d7f5ff8a9cd872a7be4ca142095956a60797cb"
+  integrity sha512-s7PoyDv/II1ObgQunCbB9PdLmUcBZcnWOcxDh7O0N/UwDEsHyqkW+Qh28jW+mVuCdx7gLB0BotYI1Y6uI9iyew==
 
 pretty-format@^25.2.1, pretty-format@^25.5.0:
   version "25.5.0"
@@ -3856,6 +3897,16 @@ pretty-format@^26.5.2:
     ansi-regex "^5.0.0"
     ansi-styles "^4.0.0"
     react-is "^16.12.0"
+
+pretty-format@^26.6.1:
+  version "26.6.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-26.6.1.tgz#af9a2f63493a856acddeeb11ba6bcf61989660a8"
+  integrity sha512-MeqqsP5PYcRBbGMvwzsyBdmAJ4EFX7pWFyl7x4+dMVg5pE0ZDdBIvEH2ergvIO+Gvwv1wh64YuOY9y5LuyY/GA==
+  dependencies:
+    "@jest/types" "^26.6.1"
+    ansi-regex "^5.0.0"
+    ansi-styles "^4.0.0"
+    react-is "^17.0.1"
 
 progress@^2.0.0:
   version "2.0.3"
@@ -3906,6 +3957,11 @@ react-is@^16.12.0, react-is@^16.8.1:
   version "16.13.1"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.13.1.tgz#789729a4dc36de2999dc156dd6c1d9c18cea56a4"
   integrity sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==
+
+react-is@^17.0.1:
+  version "17.0.1"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.1.tgz#5b3531bd76a645a4c9fb6e693ed36419e3301339"
+  integrity sha512-NAnt2iGDXohE5LI7uBnLnqvLQMtzhkiAOLXTmv+qnF9Ky7xAPcX8Up/xWIhxvLVGJvuLiNc4xQLtuqDRzb4fSA==
 
 read-pkg-up@^2.0.0:
   version "2.0.0"
@@ -4766,10 +4822,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+typescript@3.9.7:
+  version "3.9.7"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.9.7.tgz#98d600a5ebdc38f40cb277522f12dc800e9e25fa"
+  integrity sha512-BLbiRkiBzAwsjut4x/dsibSTB6yWpwT5qWmC2OfuCg3GgVQCSgMs4vEctYPhsaGtd0AeuuHMkjZ2h2WG8MSzRw==
 
 union-value@^1.0.0:
   version "1.0.1"


### PR DESCRIPTION
Adds scalars, ported from https://github.com/excitement-engineer/graphql-iso-date with one major difference: 

The scalars added in this PR will only serialize javascript Date objects (rather than Dates, date strings, or unix timestamps). This decision was made to enforce a higher code standard by keeping all dates in our code the same type. 

This could be breaking for any APIs using the excitement-engineer lib, and should be tested thoroughly before implementing