### PR TITLE
Lowering the peer dependency of GraphQL to be more flexible

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.3 (Nov 26, 2021)
+
+- Allow any GraphQL 15.x.x version
+
 ## 0.1.2 (Oct 25, 2021)
 
 - Typing `serialize` and `parseValue` methods on for a Date specific GraphQLScalarType

--- a/jest.config.js
+++ b/jest.config.js
@@ -4,14 +4,14 @@ module.exports = {
     '!<rootDir>/src/types/**/*',
     '!<rootDir>/node_modules/',
     '!<rootDir>/build/',
-    '!<rootDir>/*.js'
+    '!<rootDir>/*.js',
   ],
   globals: {
     'ts-jest': {
-      tsConfig: '<rootDir>/test/tsconfig.json'
-    }
+      tsconfig: '<rootDir>/test/tsconfig.json',
+    },
   },
   preset: 'ts-jest',
   testEnvironment: 'node',
-  testPathIgnorePatterns: ['<rootDir>/build/']
+  testPathIgnorePatterns: ['<rootDir>/build/'],
 };

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-date-scalars",
   "description": "GraphQL scalars for Date, DateTime and Time",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "peerDependencies": {
-    "graphql": "^15.6.0"
+    "graphql": "^15.0.0"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",
@@ -58,7 +58,7 @@
     "chalk": "^4.1.2",
     "eslint": "7.11.0",
     "eslint-config-neo": "0.6.2",
-    "graphql": "^15.6.0",
+    "graphql": "^15.7.2",
     "husky": "^3.1.0",
     "jest": "^27.2.5",
     "jest-matcher-utils": "^27.2.5",
@@ -68,6 +68,6 @@
     "rimraf": "^3.0.2",
     "ts-jest": "^27.0.7",
     "ts-node": "^10.3.0",
-    "typescript": "^4.4.4"
+    "typescript": "^4.5.2"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -2416,10 +2416,10 @@ graceful-fs@^4.2.4:
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.2.4.tgz#2256bde14d3632958c465ebc96dc467ca07a29fb"
   integrity sha512-WjKPNJF79dtJAVniUlGGWHYGz2jWxT6VhN/4m1NdkbZ2nOsEF+cI1Edgql5zCRhs/VsQYRvrXctxktVXZUkixw==
 
-graphql@^15.6.0:
-  version "15.6.1"
-  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.6.1.tgz#9125bdf057553525da251e19e96dab3d3855ddfc"
-  integrity sha512-3i5lu0z6dRvJ48QP9kFxBkJ7h4Kso7PS8eahyTFz5Jm6CvQfLtNIE8LX9N6JLnXTuwR+sIYnXzaWp6anOg0QQw==
+graphql@^15.7.2:
+  version "15.7.2"
+  resolved "https://registry.yarnpkg.com/graphql/-/graphql-15.7.2.tgz#85ab0eeb83722977151b3feb4d631b5f2ab287ef"
+  integrity sha512-AnnKk7hFQFmU/2I9YSQf3xw44ctnSFCfp3zE0N6W174gqe9fWG/2rKaKxROK7CcI3XtERpjEKFqts8o319Kf7A==
 
 has-bigints@^1.0.1:
   version "1.0.1"
@@ -4741,10 +4741,10 @@ typedarray-to-buffer@^3.1.5:
   dependencies:
     is-typedarray "^1.0.0"
 
-typescript@^4.4.4:
-  version "4.4.4"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.4.4.tgz#2cd01a1a1f160704d3101fd5a58ff0f9fcb8030c"
-  integrity sha512-DqGhF5IKoBl8WNf8C1gu8q0xZSInh9j1kJJMqT3a94w1JzVaBU4EXOSMrz9yDqMT0xt3selp83fuFMQ0uzv6qA==
+typescript@^4.5.2:
+  version "4.5.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.5.2.tgz#8ac1fba9f52256fdb06fb89e4122fa6a346c2998"
+  integrity sha512-5BlMof9H1yGt0P8/WF+wPNw6GfctgGjXp5hkblpyT+8rkASSmkUKMXrxR0Xg8ThVCi/JnHQiKXeBaEwCeQwMFw==
 
 unbox-primitive@^1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Package will work with any 15.x.x version of GraphQL

I attempted to support GraphQL 16 in this change but not wasn't as easy as I hoped. Will do this in a future version