### PR TITLE
Fix scalar types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,5 @@ node_modules
 .vscode
 
 *.log
+
+.DS_Store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.1.4 (Apr 6, 2022)
+
+- Fix ScalarTypes to not return undefined. The functions will either throw or return value.
+
 ## 0.1.3 (Nov 26, 2021)
 
 - Allow any GraphQL 15.x.x version

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 GraphQL Scalars for Date (YYYY-MM-DD), DateTime (YYYY-MM-DDTHH:MM:SSZ), and Time (HH:MM:SSZ)
 
-## Usage
+## Schema Usage
 
 ```ts
 import { gql, ApolloServer } from 'apollo-server';
@@ -69,6 +69,33 @@ generates:
   src/types/example-schema.d.ts:
     plugins:
       - 'typescript'
+```
+
+## Direct Usage
+
+You can also use the parse and serialize methods directly, which is useful if you are
+making a rest call to a 3rd party vendor.
+
+```ts
+import { DateTimeScalar } from 'graphql-date-scalars';
+
+const vendorResponse = await restClient.get();
+
+const response = {
+  ...vendorResponse,
+  createdAt: DateTimeScalar.parseValue(vendorResponse.createdAt),
+};
+```
+
+```ts
+import { DateScalar } from 'graphql-date-scalars';
+
+const args = {
+  ...input,
+  dateOfBirth: DateScalar.serialize(input.dateOfBirth),
+};
+
+const response = await restClient.post(args);
 ```
 
 ## Contributing

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "graphql-date-scalars",
   "description": "GraphQL scalars for Date, DateTime and Time",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "author": "Neo Financial Engineering <engineering@neofinancial.com>",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -5,5 +5,5 @@ export class GraphQLDateScalarType extends GraphQLScalarType {
   parseValue: GraphQLScalarValueParser<string, Date> = this.toConfig().parseValue;
 }
 
-export type GraphQLScalarSerializer<TIn, TOut> = (value: TIn) => TOut | undefined;
-export type GraphQLScalarValueParser<TIn, TOut> = (value: TIn) => TOut | undefined;
+export type GraphQLScalarSerializer<TIn, TOut> = (value: TIn) => TOut;
+export type GraphQLScalarValueParser<TIn, TOut> = (value: TIn) => TOut;


### PR DESCRIPTION
These types use underlying utilities that do not return undefined and the functions themselves will throw if the input is not correct.

Sp these types do not need to say they return undefined, they will either return the correct type or throw.