### PR TITLE
Chore/add dependency support for graphql 16

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     ]
   },
   "peerDependencies": {
-    "graphql": "^15.0.0"
+    "graphql": "^16.0.0 ||^15.0.0"
   },
   "devDependencies": {
     "@types/jest": "27.0.2",

--- a/src/utils/validator.ts
+++ b/src/utils/validator.ts
@@ -37,7 +37,7 @@ const leapYear = (year: number): boolean => {
 // - Leap seconds cannot be known in advance.
 //
 export const validateTime = (time: string): boolean => {
-  const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d{1,})?(([Z])|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
+  const TIME_REGEX = /^([01]\d|2[0-3]):([0-5]\d):([0-5]\d)(\.\d+)?((Z)|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
 
   return TIME_REGEX.test(time);
 };
@@ -66,7 +66,7 @@ export const validateTime = (time: string): boolean => {
 // 12            December             31
 //
 export const validateDate = (dateString: string): boolean => {
-  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01]))$/;
+  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01]))$/;
 
   if (!RFC_3339_REGEX.test(dateString)) {
     return false;
@@ -113,7 +113,8 @@ export const validateDate = (dateString: string): boolean => {
 // Where *s is a fraction of seconds with at least 1 digit.
 //
 export const validateDateTime = (dateTimeString: string): boolean => {
-  const RFC_3339_REGEX = /^(\d{4}-(0[1-9]|1[012])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60))(\.\d{1,})?(([Z])|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
+  const RFC_3339_REGEX =
+    /^(\d{4}-(0[1-9]|1[0-2])-(0[1-9]|[12]\d|3[01])T([01]\d|2[0-3]):([0-5]\d):([0-5]\d|60))(\.\d+)?((Z)|([+|-]([01]\d|2[0-3]):[0-5]\d))$/;
 
   // Validate the structure of the date-string
   if (!RFC_3339_REGEX.test(dateTimeString)) {


### PR DESCRIPTION
## What we have done
- [chore: add dependency support for graphqlV16](https://github.com/neofinancial/graphql-date-scalars/commit/c5cc29c04c6d2215e130f122a760671ceb21012f)
- [chore: apply linting rules to validator module](https://github.com/neofinancial/graphql-date-scalars/commit/2a681626201935a93be624d26e60af21606ae093)